### PR TITLE
[kie-roadmap#101] Include dependencies in the Maven repository zip

### DIFF
--- a/bamoe-maven-repository-zip/maven-repository-zip-assembly.xml
+++ b/bamoe-maven-repository-zip/maven-repository-zip-assembly.xml
@@ -9,13 +9,12 @@
       <directory>${m2.repo.location}</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>**/bamoe/**</include>
-        <include>**/drools/**</include>
-        <include>**/kie/**</include>
+        <include>**</include>
       </includes>
       <excludes>
         <exclude>**/_remote.repositories</exclude>
-        <exclude>**/maven-metadata-local.xml</exclude>
+        <exclude>**/maven-metadata**</exclude>
+        <exclude>**/resolver-status.properties</exclude>
       </excludes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
- With this change, the repository should be able to serve as an offline Maven repository for BAMOE artifacts. 